### PR TITLE
feat(common): add empty screens

### DIFF
--- a/lib/common/empty_screen.dart
+++ b/lib/common/empty_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class EmptyScreen extends StatelessWidget {
+  const EmptyScreen({super.key, required this.text});
+  final String text;
+
+  const EmptyScreen.training({super.key})
+      : text = 'Вы не записали ни одной тренировки';
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Center(
+          child: Text(text),
+        )
+      ],
+    );
+  }
+}

--- a/lib/trainings_screen.dart
+++ b/lib/trainings_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
+import 'package:training_note/common/empty_screen.dart';
 import 'package:training_note/date_formating_extension.dart';
 import 'package:training_note/empty_training.dart';
 import 'package:training_note/training_details_screen.dart';
@@ -14,36 +15,38 @@ class TrainingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: ListView.separated(
-        itemCount: trainings.length,
-        separatorBuilder: (_, __) => const SizedBox(height: 16),
-        itemBuilder: (context, index) => InkWell(
-          onTap: () {
-            Navigator.push(
-                context,
-                MaterialPageRoute<void>(
-                    builder: (context) => TrainingDetailsScreen(
-                          trainings: trainings[index],
-                        )));
-          },
-          child: Card(
-            child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                        'Дата тренировки: ${trainings[index].date.formatData()}'),
-                    SizedBox(
-                      height: 8,
-                    ),
-                    Text(
-                        'Количество подходов: ${trainings[index].approach.length}'),
-                  ],
-                )),
-          ),
-        ),
-      ),
+      body: trainings.isEmpty
+          ? EmptyScreen.training()
+          : ListView.separated(
+              itemCount: trainings.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 16),
+              itemBuilder: (context, index) => InkWell(
+                onTap: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute<void>(
+                          builder: (context) => TrainingDetailsScreen(
+                                trainings: trainings[index],
+                              )));
+                },
+                child: Card(
+                  child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                              'Дата тренировки: ${trainings[index].date.formatData()}'),
+                          SizedBox(
+                            height: 8,
+                          ),
+                          Text(
+                              'Количество подходов: ${trainings[index].approach.length}'),
+                        ],
+                      )),
+                ),
+              ),
+            ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           add();


### PR DESCRIPTION
1) Добавлен виджет `EmptyScreen` для отображения заглушки с текстом посередине
2) В `TrainingsScreen` реализована проверка на пустой список: если тренировок нет, вместо пустого списка выводится `EmptyScreen`.
Close: #28 